### PR TITLE
Uses the `$get` syntax with dependencies

### DIFF
--- a/src/agcLibraryLoader.js
+++ b/src/agcLibraryLoader.js
@@ -9,17 +9,16 @@
 
         var DEFAULT_LOADER = "Jsapi";
 
-        this.$get = function(loader){
-            return loader;
-        };
-
         this.setLoader = function(loaderName){
-            if ($injector.has(this.getProviderName(loaderName)))
-                this.$get.$inject = [this.getProviderName(loaderName)];
-            else {
+            if (!$injector.has(this.getProviderName(loaderName))) {
                 console.warn("[Angular-GoogleChart] Loader type \"" + loaderName + "\" doesn't exist. Defaulting to JSAPI loader.");
-                this.$get.$inject = [this.getProviderName(DEFAULT_LOADER)];
+
+                loaderName = DEFAULT_LOADER;
             }
+            
+            this.$get = [this.getProviderName(loaderName), function(loader) {
+                return loader;
+            }];
         };
 
         this.getProviderName = function(loaderName){


### PR DESCRIPTION
Right now, [ng-annotate](https://github.com/olov/ng-annotate) will transform the `$get` method to its with-dependencies syntax:
```
this.$get = ['loader', function(loader) {
    return loader;
}];
```

As this syntax takes precedence over the `$inject` property, the application will fail to load because of a missing `loader` dependency.

This PR changes the way the `$get` method is set, to make it "ng-annotate-safe" and use the with-dependency syntax.